### PR TITLE
curl follow redirect

### DIFF
--- a/templates/CVE_Scan.gitlab-ci.yml
+++ b/templates/CVE_Scan.gitlab-ci.yml
@@ -23,7 +23,7 @@
     # Get Trivy
     - |
       mkdir -p bin/trivy-${TRIVY_BIN_VERSION}
-      curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" ${CI_API_V4_URL}/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
+      curl -L ${CI_API_V4_URL}/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
       chmod u+x bin/trivy-${TRIVY_BIN_VERSION}/trivy
       ln -s ${PWD}/bin/trivy-${TRIVY_BIN_VERSION}/trivy bin/trivy
       if [[ "${TRIVY_CACHE_CLEAN}" == "true" ]]; then


### PR DESCRIPTION
Description
For some reason Trivy binary changed location in S3, so curl can not download it as it receives message "This resource has been moved temporarily to"

Why do we need it, and what problem does it solve?
Added following to redirects for curl