### PR TITLE
Add GitLab CI template for secret scanning with Gitleaks

### DIFF
--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -1,6 +1,5 @@
 stages:
   - gitleaks
-  - gitleaks_cleanup
 
 variables:
   GITLEAKS_VERSION: "v8.28.0"
@@ -100,6 +99,10 @@ variables:
       else
         echo "✅ No leaks found."
       fi
+      
+      # ========== Cleanup ==========
+      echo "🧹 Cleaning up runner workspace..."
+      rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz gitleaks.json || true
 
   artifacts:
     when: always
@@ -129,11 +132,3 @@ gitleaks_full_scheduled:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
 
-gitleaks_cleanup:
-  stage: gitleaks_cleanup
-  before_script: []
-  script:
-    - echo "🧹 Cleaning up runner workspace..."
-    - rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz gitleaks.json || true
-  rules:
-    - when: always

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -28,7 +28,9 @@ variables:
       curl -sSL "$base/$tgz" -o gitleaks.tgz
       tar -xzf gitleaks.tgz gitleaks
       chmod +x gitleaks
-      mv gitleaks /usr/local/bin/
+      mkdir -p "$HOME/.local/bin"
+      mv gitleaks "$HOME/.local/bin/"
+      export PATH="$HOME/.local/bin:$PATH"
       gitleaks version
 
     # Check for config
@@ -94,7 +96,7 @@ variables:
       fi
 
   after_script:
-    - rm -f /usr/local/bin/gitleaks gitleaks.tgz gitleaks.json || true
+    - rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz gitleaks.json || true
 
   artifacts:
     when: always

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -131,6 +131,7 @@ gitleaks_full_scheduled:
 
 gitleaks_cleanup:
   stage: gitleaks_cleanup
+  before_script: []
   script:
     - echo "🧹 Cleaning up runner workspace..."
     - rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz gitleaks.json || true

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -72,8 +72,6 @@ variables:
         COUNT=$(jq length gitleaks.json)
         echo "❌ Leaks found: $COUNT"
         echo ""
-        echo "| Rule | Location | Commit | Link |"
-        echo "|------|----------|--------|------|"
         jq -r '
           def norm:
             {
@@ -85,8 +83,12 @@ variables:
           (if type=="object" and has("findings") then .findings
            elif type=="array" then .
            else [] end)[] | norm
-          | "| \(.rule) | \(.file):\(.line) | \(.commit[0:7]) | https://'$CI_PROJECT_PATH'/blob/\(.commit)/\(.file)#L\(.line) |"
-        ' gitleaks.json | head -n 200
+          | [.rule, (.file+":"+.line|tostring), (.commit[0:7]),
+             ("https://'$CI_PROJECT_PATH'/blob/"+.commit+"/"+.file+"#L"+(.line|tostring))]
+          | @tsv
+        ' gitleaks.json | head -n 200 | while IFS=$'\t' read -r rule loc sha link; do
+          printf '• [%s] %s %s %s\n' "$rule" "$loc" "$sha" "$link"
+        done
       else
         echo "✅ No leaks found."
       fi

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -2,12 +2,34 @@ stages:
   - gitleaks
 
 .gitleaks_scan:
-  image: alpine:latest
   tags:
     - tfprod-distributed-werf
   stage: gitleaks
   before_script:
-    - apk add --no-cache curl bash git jq tar
+    - set -euo pipefail
+    - |
+      # Ensure basic tools (curl/wget, tar, jq) are available in both shell and container executors
+      if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+        if [ -f /etc/alpine-release ]; then
+          apk add --no-cache curl || true
+        elif [ -f /etc/debian_version ]; then
+          apt-get update -y && apt-get install -y curl || true
+        fi
+      fi
+      if ! command -v jq >/dev/null 2>&1; then
+        if [ -f /etc/alpine-release ]; then
+          apk add --no-cache jq || true
+        elif [ -f /etc/debian_version ]; then
+          apt-get update -y && apt-get install -y jq || true
+        fi
+      fi
+      if ! command -v tar >/dev/null 2>&1; then
+        if [ -f /etc/alpine-release ]; then
+          apk add --no-cache tar || true
+        elif [ -f /etc/debian_version ]; then
+          apt-get update -y && apt-get install -y tar || true
+        fi
+      fi
     - |
       echo "📥 Installing Gitleaks..."
       ver="v8.28.0"
@@ -20,23 +42,31 @@ stages:
       esac
       base="https://github.com/gitleaks/gitleaks/releases/download/${ver}"
       tgz="gitleaks_${file_ver}_${pkg_arch}.tar.gz"
-      curl -sSL "$base/$tgz" -o gitleaks.tgz
+      if command -v curl >/dev/null 2>&1; then
+        curl -sSL "$base/$tgz" -o gitleaks.tgz
+      else
+        wget -qO gitleaks.tgz "$base/$tgz"
+      fi
       tar -xzf gitleaks.tgz gitleaks
       chmod +x gitleaks
-      mv gitleaks /usr/local/bin/
+      # Try to put into PATH (works on shell runners); fallback to current dir
+      mv -f gitleaks /usr/local/bin/gitleaks 2>/dev/null || mv -f gitleaks ./gitleaks
+      if ! command -v gitleaks >/dev/null 2>&1; then
+        export PATH="$PWD:$PATH"
+      fi
       gitleaks version
   script:
     - |
-      if [[ ! -f "gitleaks.toml" ]]; then
+      if [ ! -f "gitleaks.toml" ]; then
         echo "❌ Missing config 'gitleaks.toml'"
         exit 1
       fi
 
       echo "🕵️ Running Gitleaks in mode: $SCAN_MODE"
 
-      if [[ "$SCAN_MODE" == "diff" ]]; then
+      if [ "$SCAN_MODE" = "diff" ]; then
         BASE_SHA=$(git merge-base origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME HEAD || echo "")
-        if [[ -z "$BASE_SHA" ]]; then
+        if [ -z "$BASE_SHA" ]; then
           echo "⚠️ Base SHA not found, falling back to full scan"
           SCAN_MODE="full"
         else
@@ -47,7 +77,7 @@ stages:
         fi
       fi
 
-      if [[ "$SCAN_MODE" == "full" ]]; then
+      if [ "$SCAN_MODE" = "full" ]; then
         echo "▶ Running full scan"
         gitleaks detect --no-banner \
           --report-format json --report-path gitleaks.json \
@@ -55,7 +85,7 @@ stages:
       fi
 
       echo "📄 Report Summary"
-      if [[ -f gitleaks.json ]]; then
+      if [ -f gitleaks.json ]; then
         COUNT=$(jq 'if type=="array" then length else 0 end' gitleaks.json)
         echo "Findings: $COUNT"
       else
@@ -65,6 +95,13 @@ stages:
     when: always
     paths:
       - gitleaks.json
+    expire_in: 1 week
+  after_script:
+    - |
+      # Cleanup temporary files; keep gitleaks.json for artifact collection
+      rm -f /usr/local/bin/gitleaks 2>/dev/null || true
+      rm -f ./gitleaks 2>/dev/null || true
+      rm -f gitleaks.tgz 2>/dev/null || true
   allow_failure: true
 
 gitleaks_diff:

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -133,8 +133,12 @@ gitleaks_cleanup:
   needs:
     - job: gitleaks_diff
       artifacts: true
+      optional: true
     - job: gitleaks_full_manual
       artifacts: true
+      optional: true
     - job: gitleaks_full_scheduled
       artifacts: true
-  when: always
+      optional: true
+  rules:
+    - if: '$CI_JOB_STATUS == "success" || $CI_JOB_STATUS == "failed"'

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -102,7 +102,7 @@ variables:
       
       # ========== Cleanup ==========
       echo "🧹 Cleaning up runner workspace..."
-      rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz gitleaks.json || true
+      rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz || true
 
   artifacts:
     when: always

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -135,15 +135,5 @@ gitleaks_cleanup:
   script:
     - echo "🧹 Cleaning up runner workspace..."
     - rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz gitleaks.json || true
-  needs:
-    - job: gitleaks_diff
-      artifacts: true
-      optional: true
-    - job: gitleaks_full_manual
-      artifacts: true
-      optional: true
-    - job: gitleaks_full_scheduled
-      artifacts: true
-      optional: true
   rules:
     - when: always

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -45,7 +45,7 @@ variables:
       GITLEAKS_EXIT=0
       if [[ "$SCAN_MODE" == "diff" ]]; then
         echo "🕵️ Running in DIFF mode..."
-        git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --depth=0
+        git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --depth=1
         BASE_SHA=$(git merge-base origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME HEAD || echo "")
         if [[ -z "$BASE_SHA" ]]; then
           echo "❌ BASE_SHA not found. Aborting."

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -1,0 +1,64 @@
+.gitleaks_scan:
+  image: alpine:latest
+  before_script:
+    - apk add --no-cache curl bash git jq tar
+    - |
+      echo "📥 Installing Gitleaks..."
+      ver="v8.28.0"
+      file_ver="${ver#v}"
+      arch="$(uname -m)"
+      case "$arch" in
+        x86_64|amd64)  pkg_arch="linux_x64" ;;
+        aarch64|arm64) pkg_arch="linux_arm64" ;;
+        *) echo "Unsupported arch: $arch"; exit 1 ;;
+      esac
+      base="https://github.com/gitleaks/gitleaks/releases/download/${ver}"
+      tgz="gitleaks_${file_ver}_${pkg_arch}.tar.gz"
+      curl -sSL "$base/$tgz" -o gitleaks.tgz
+      tar -xzf gitleaks.tgz gitleaks
+      chmod +x gitleaks
+      mv gitleaks /usr/local/bin/
+      gitleaks version
+  script:
+    - |
+      if [[ ! -f ".github/gitleaks.toml" ]]; then
+        echo "❌ Missing config '.github/gitleaks.toml'"
+        exit 1
+      fi
+
+      echo "🕵️ Running Gitleaks in mode: $SCAN_MODE"
+
+      if [[ "$SCAN_MODE" == "diff" ]]; then
+        BASE_SHA=$(git merge-base origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME HEAD || echo "")
+        if [[ -z "$BASE_SHA" ]]; then
+          echo "⚠️ Base SHA not found, falling back to full scan"
+          SCAN_MODE="full"
+        else
+          echo "▶ Running diff scan $BASE_SHA...HEAD"
+          gitleaks detect --no-banner \
+            --report-format json --report-path gitleaks.json \
+            -c .github/gitleaks.toml --source . --log-opts "$BASE_SHA...HEAD"
+        fi
+      fi
+
+      if [[ "$SCAN_MODE" == "full" ]]; then
+        echo "▶ Running full scan"
+        gitleaks detect --no-banner \
+          --report-format json --report-path gitleaks.json \
+          -c .github/gitleaks.toml --source .
+      fi
+
+      echo "📄 Report Summary"
+      if [[ -f gitleaks.json ]]; then
+        COUNT=$(jq 'if type=="array" then length else 0 end' gitleaks.json)
+        echo "Findings: $COUNT"
+      else
+        echo "No report found"
+      fi
+  artifacts:
+    when: always
+    paths:
+      - gitleaks.json
+    reports:
+      dotenv: # можно прикрутить вывод переменных или json анализ
+  allow_failure: true

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -65,12 +65,12 @@ stages:
     when: always
     paths:
       - gitleaks.json
-    reports:
-      dotenv:
   allow_failure: true
 
 gitleaks_diff:
   extends: .gitleaks_scan
+  tags:
+    - tfprod-distributed-werf
   variables:
     SCAN_MODE: "diff"
   rules:
@@ -78,6 +78,8 @@ gitleaks_diff:
 
 gitleaks_full:
   extends: .gitleaks_scan
+  tags:
+    - tfprod-distributed-werf
   variables:
     SCAN_MODE: "full"
   rules:

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
 
 .gitleaks_scan:
   stage: gitleaks
+  before_script: []
   script:
     - set -euo pipefail
 

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -3,6 +3,8 @@ stages:
 
 .gitleaks_scan:
   image: alpine:latest
+  tags:
+    - tfprod-distributed-werf
   stage: gitleaks
   before_script:
     - apk add --no-cache curl bash git jq tar
@@ -79,4 +81,4 @@ gitleaks_full:
   variables:
     SCAN_MODE: "full"
   rules:
-    - if: '$CI_PIPELINE_SOURCE != "merge_request_event"'
+    - if: '$CI_PIPELINE_SOURCE == "web"'

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -99,10 +99,10 @@ variables:
       else
         echo "✅ No leaks found."
       fi
-      
-      # ========== Cleanup ==========
-      echo "🧹 Cleaning up runner workspace..."
-      rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz || true
+
+  after_script:
+    - echo "🧹 Cleaning up runner workspace..."
+    - rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz || true
 
   artifacts:
     when: always

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -55,15 +55,17 @@ variables:
           exit 1
         fi
         echo "▶ Scanning diff: $BASE_SHA...HEAD"
-        gitleaks detect --no-banner --report-format json --report-path gitleaks.json $CONFIG_ARG --source . --log-opts "$BASE_SHA...HEAD"
+        gitleaks detect --no-banner --report-format json --report-path gitleaks.json $CONFIG_ARG --source . --log-opts "$BASE_SHA...HEAD" || GITLEAKS_EXIT=$?
 
       elif [[ "$SCAN_MODE" == "full" ]]; then
         echo "🕵️ Running in FULL mode..."
-        gitleaks detect --no-banner --report-format json --report-path gitleaks.json $CONFIG_ARG --source .
+        gitleaks detect --no-banner --report-format json --report-path gitleaks.json $CONFIG_ARG --source . || GITLEAKS_EXIT=$?
       else
         echo "❌ Unknown SCAN_MODE: $SCAN_MODE"
         exit 1
       fi
+      
+      echo "🔍 Gitleaks exit code: ${GITLEAKS_EXIT:-0}"
 
     # Parse and print results
     - |
@@ -75,20 +77,23 @@ variables:
         jq -r '
           def norm:
             {
-              file: (.File // .file // .Target // .Location.File // ""),
+              file: (.File // .file // .Target // .Location.File // "unknown"),
               line: (.StartLine // .Line // .Location.StartLine // 0),
-              rule: (.RuleID // .Rule // .Description // ""),
+              rule: (.RuleID // .Rule // .Description // "unknown"),
               commit: (.Commit // .commit // "")
             };
           (if type=="object" and has("findings") then .findings
            elif type=="array" then .
            else [] end)[] | norm
-          | [.rule, (.file+":"+.line|tostring), (.commit[0:7]),
-             ("https://'$CI_PROJECT_PATH'/blob/"+.commit+"/"+.file+"#L"+(.line|tostring))]
-          | @tsv
-        ' gitleaks.json | head -n 200 | while IFS=$'\t' read -r rule loc sha link; do
-          printf '• [%s] %s %s %s\n' "$rule" "$loc" "$sha" "$link"
-        done
+          | "• [\(.rule)] \(.file):\(.line) \(.commit[0:7] // "no-commit") https://'$CI_PROJECT_PATH'/blob/\(.commit)/\(.file)#L\(.line)"
+        ' gitleaks.json | head -n 200
+        
+        # Fail the job if leaks were found
+        if [[ "$COUNT" -gt 0 ]]; then
+          echo ""
+          echo "❌ Pipeline failed due to $COUNT leak(s). Review gitleaks.json artifact."
+          exit 1
+        fi
       else
         echo "✅ No leaks found."
       fi

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -67,13 +67,13 @@ variables:
 
     # Parse and print results
     - |
-      if [[ -f gitleaks.json ]]; then
-        COUNT=$(jq -r 'if type=="array" then length else (if has("findings") then .findings|length else 0 end) end' gitleaks.json)
-        echo "🔎 Findings: $COUNT"
-        LIMIT=200
-        echo -e "\n| Rule | File:Line | Commit | Link |"
-        echo "|------|------------|--------|------|"
-
+      echo "📤 Parsing gitleaks.json for CI log output..."
+      if [[ -s gitleaks.json ]]; then
+        COUNT=$(jq length gitleaks.json)
+        echo "❌ Leaks found: $COUNT"
+        echo ""
+        echo "| Rule | Location | Commit | Link |"
+        echo "|------|----------|--------|------|"
         jq -r '
           def norm:
             {
@@ -85,15 +85,10 @@ variables:
           (if type=="object" and has("findings") then .findings
            elif type=="array" then .
            else [] end)[] | norm
-        ' gitleaks.json \
-        | head -n "$LIMIT" \
-        | jq -s -r '.[] | "| \(.rule) | \(.file):\(.line) | \(.commit[0:7]) | https://$CI_PROJECT_PATH/blob/\(.commit)/\(.file)#L\(.line) |"' || true
-
-        if (( COUNT > LIMIT )); then
-          echo "... and $((COUNT - LIMIT)) more (see gitleaks.json artifact)"
-        fi
+          | "| \(.rule) | \(.file):\(.line) | \(.commit[0:7]) | https://'$CI_PROJECT_PATH'/blob/\(.commit)/\(.file)#L\(.line) |"
+        ' gitleaks.json | head -n 200
       else
-        echo "ℹ️ No gitleaks.json found"
+        echo "✅ No leaks found."
       fi
 
 

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -9,10 +9,10 @@ variables:
   stage: gitleaks
   before_script: []
   script:
-    - set -euo pipefail
-
-    # Determine arch
     - |
+      set -euo pipefail
+      
+      # ========== Install Gitleaks ==========
       echo "📥 Installing Gitleaks $GITLEAKS_VERSION..."
       file_ver="${GITLEAKS_VERSION#v}"
       arch="$(uname -m)"
@@ -21,9 +21,7 @@ variables:
         aarch64|arm64) pkg_arch="linux_arm64" ;;
         *) echo "Unsupported arch: $arch"; exit 1 ;;
       esac
-
-    # Download and install
-    - |
+      
       base="https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}"
       tgz="gitleaks_${file_ver}_${pkg_arch}.tar.gz"
       curl -sSL "$base/$tgz" -o gitleaks.tgz
@@ -33,9 +31,8 @@ variables:
       mv gitleaks "$HOME/.local/bin/"
       export PATH="$HOME/.local/bin:$PATH"
       gitleaks version
-
-    # Check for config
-    - |
+      
+      # ========== Check for config ==========
       if [[ -f "gitleaks.toml" ]]; then
         CONFIG_ARG="-c gitleaks.toml"
         echo "✅ Found config: gitleaks.toml"
@@ -43,9 +40,9 @@ variables:
         CONFIG_ARG=""
         echo "⚠️ Config file not found. Proceeding with default rules."
       fi
-
-    # Run scan
-    - |
+      
+      # ========== Run scan ==========
+      GITLEAKS_EXIT=0
       if [[ "$SCAN_MODE" == "diff" ]]; then
         echo "🕵️ Running in DIFF mode..."
         git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --depth=0
@@ -56,7 +53,6 @@ variables:
         fi
         echo "▶ Scanning diff: $BASE_SHA...HEAD"
         gitleaks detect --no-banner --report-format json --report-path gitleaks.json $CONFIG_ARG --source . --log-opts "$BASE_SHA...HEAD" || GITLEAKS_EXIT=$?
-
       elif [[ "$SCAN_MODE" == "full" ]]; then
         echo "🕵️ Running in FULL mode..."
         gitleaks detect --no-banner --report-format json --report-path gitleaks.json $CONFIG_ARG --source . || GITLEAKS_EXIT=$?
@@ -65,15 +61,19 @@ variables:
         exit 1
       fi
       
-      echo "🔍 Gitleaks exit code: ${GITLEAKS_EXIT:-0}"
-
-    # Parse and print results
-    - |
+      echo "🔍 Gitleaks exit code: $GITLEAKS_EXIT"
+      
+      # ========== Parse and print results ==========
       echo "📤 Parsing gitleaks.json for CI log output..."
+      echo "DEBUG: Checking gitleaks.json file..."
+      ls -lh gitleaks.json || echo "⚠️ gitleaks.json not found!"
+      
       if [[ -s gitleaks.json ]]; then
         COUNT=$(jq length gitleaks.json)
         echo "❌ Leaks found: $COUNT"
         echo ""
+        echo "DEBUG: Attempting to parse and display leaks..."
+        
         jq -r '
           def norm:
             {
@@ -88,6 +88,9 @@ variables:
           | "• [\(.rule)] \(.file):\(.line) \(.commit[0:7] // "no-commit") https://'$CI_PROJECT_PATH'/blob/\(.commit)/\(.file)#L\(.line)"
         ' gitleaks.json | head -n 200
         
+        echo ""
+        echo "DEBUG: Finished displaying leaks"
+        
         # Fail the job if leaks were found
         if [[ "$COUNT" -gt 0 ]]; then
           echo ""
@@ -97,7 +100,6 @@ variables:
       else
         echo "✅ No leaks found."
       fi
-
 
   artifacts:
     when: always

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - gitleaks
+  - gitleaks_cleanup
 
 variables:
   GITLEAKS_VERSION: "v8.28.0"
@@ -95,8 +96,6 @@ variables:
         echo "ℹ️ No gitleaks.json found"
       fi
 
-  after_script:
-    - rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz gitleaks.json || true
 
   artifacts:
     when: always
@@ -125,3 +124,17 @@ gitleaks_full_scheduled:
     SCAN_MODE: "full"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
+
+gitleaks_cleanup:
+  stage: gitleaks_cleanup
+  script:
+    - echo "🧹 Cleaning up runner workspace..."
+    - rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz gitleaks.json || true
+  needs:
+    - job: gitleaks_diff
+      artifacts: true
+    - job: gitleaks_full_manual
+      artifacts: true
+    - job: gitleaks_full_scheduled
+      artifacts: true
+  when: always

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -1,5 +1,9 @@
+stages:
+  - gitleaks
+
 .gitleaks_scan:
   image: alpine:latest
+  stage: gitleaks
   before_script:
     - apk add --no-cache curl bash git jq tar
     - |
@@ -21,8 +25,8 @@
       gitleaks version
   script:
     - |
-      if [[ ! -f ".github/gitleaks.toml" ]]; then
-        echo "❌ Missing config '.github/gitleaks.toml'"
+      if [[ ! -f "gitleaks.toml" ]]; then
+        echo "❌ Missing config 'gitleaks.toml'"
         exit 1
       fi
 
@@ -37,7 +41,7 @@
           echo "▶ Running diff scan $BASE_SHA...HEAD"
           gitleaks detect --no-banner \
             --report-format json --report-path gitleaks.json \
-            -c .github/gitleaks.toml --source . --log-opts "$BASE_SHA...HEAD"
+            -c gitleaks.toml --source . --log-opts "$BASE_SHA...HEAD"
         fi
       fi
 
@@ -45,7 +49,7 @@
         echo "▶ Running full scan"
         gitleaks detect --no-banner \
           --report-format json --report-path gitleaks.json \
-          -c .github/gitleaks.toml --source .
+          -c gitleaks.toml --source .
       fi
 
       echo "📄 Report Summary"
@@ -60,5 +64,19 @@
     paths:
       - gitleaks.json
     reports:
-      dotenv: # можно прикрутить вывод переменных или json анализ
+      dotenv:
   allow_failure: true
+
+gitleaks_diff:
+  extends: .gitleaks_scan
+  variables:
+    SCAN_MODE: "diff"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+
+gitleaks_full:
+  extends: .gitleaks_scan
+  variables:
+    SCAN_MODE: "full"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "merge_request_event"'

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -145,4 +145,4 @@ gitleaks_cleanup:
       artifacts: true
       optional: true
   rules:
-    - if: '$CI_JOB_STATUS == "success" || $CI_JOB_STATUS == "failed"'
+    - when: always

--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -1,123 +1,124 @@
 stages:
   - gitleaks
 
+variables:
+  GITLEAKS_VERSION: "v8.28.0"
+
 .gitleaks_scan:
-  tags:
-    - tfprod-distributed-werf
   stage: gitleaks
-  before_script:
+  script:
     - set -euo pipefail
+
+    # Determine arch
     - |
-      # Ensure basic tools (curl/wget, tar, jq) are available in both shell and container executors
-      if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
-        if [ -f /etc/alpine-release ]; then
-          apk add --no-cache curl || true
-        elif [ -f /etc/debian_version ]; then
-          apt-get update -y && apt-get install -y curl || true
-        fi
-      fi
-      if ! command -v jq >/dev/null 2>&1; then
-        if [ -f /etc/alpine-release ]; then
-          apk add --no-cache jq || true
-        elif [ -f /etc/debian_version ]; then
-          apt-get update -y && apt-get install -y jq || true
-        fi
-      fi
-      if ! command -v tar >/dev/null 2>&1; then
-        if [ -f /etc/alpine-release ]; then
-          apk add --no-cache tar || true
-        elif [ -f /etc/debian_version ]; then
-          apt-get update -y && apt-get install -y tar || true
-        fi
-      fi
-    - |
-      echo "📥 Installing Gitleaks..."
-      ver="v8.28.0"
-      file_ver="${ver#v}"
+      echo "📥 Installing Gitleaks $GITLEAKS_VERSION..."
+      file_ver="${GITLEAKS_VERSION#v}"
       arch="$(uname -m)"
       case "$arch" in
         x86_64|amd64)  pkg_arch="linux_x64" ;;
         aarch64|arm64) pkg_arch="linux_arm64" ;;
         *) echo "Unsupported arch: $arch"; exit 1 ;;
       esac
-      base="https://github.com/gitleaks/gitleaks/releases/download/${ver}"
+
+    # Download and install
+    - |
+      base="https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}"
       tgz="gitleaks_${file_ver}_${pkg_arch}.tar.gz"
-      if command -v curl >/dev/null 2>&1; then
-        curl -sSL "$base/$tgz" -o gitleaks.tgz
-      else
-        wget -qO gitleaks.tgz "$base/$tgz"
-      fi
+      curl -sSL "$base/$tgz" -o gitleaks.tgz
       tar -xzf gitleaks.tgz gitleaks
       chmod +x gitleaks
-      # Try to put into PATH (works on shell runners); fallback to current dir
-      mv -f gitleaks /usr/local/bin/gitleaks 2>/dev/null || mv -f gitleaks ./gitleaks
-      if ! command -v gitleaks >/dev/null 2>&1; then
-        export PATH="$PWD:$PATH"
-      fi
+      mv gitleaks /usr/local/bin/
       gitleaks version
-  script:
+
+    # Check for config
     - |
-      if [ ! -f "gitleaks.toml" ]; then
-        echo "❌ Missing config 'gitleaks.toml'"
+      if [[ -f "gitleaks.toml" ]]; then
+        CONFIG_ARG="-c gitleaks.toml"
+        echo "✅ Found config: gitleaks.toml"
+      else
+        CONFIG_ARG=""
+        echo "⚠️ Config file not found. Proceeding with default rules."
+      fi
+
+    # Run scan
+    - |
+      if [[ "$SCAN_MODE" == "diff" ]]; then
+        echo "🕵️ Running in DIFF mode..."
+        git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --depth=0
+        BASE_SHA=$(git merge-base origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME HEAD || echo "")
+        if [[ -z "$BASE_SHA" ]]; then
+          echo "❌ BASE_SHA not found. Aborting."
+          exit 1
+        fi
+        echo "▶ Scanning diff: $BASE_SHA...HEAD"
+        gitleaks detect --no-banner --report-format json --report-path gitleaks.json $CONFIG_ARG --source . --log-opts "$BASE_SHA...HEAD"
+
+      elif [[ "$SCAN_MODE" == "full" ]]; then
+        echo "🕵️ Running in FULL mode..."
+        gitleaks detect --no-banner --report-format json --report-path gitleaks.json $CONFIG_ARG --source .
+      else
+        echo "❌ Unknown SCAN_MODE: $SCAN_MODE"
         exit 1
       fi
 
-      echo "🕵️ Running Gitleaks in mode: $SCAN_MODE"
+    # Parse and print results
+    - |
+      if [[ -f gitleaks.json ]]; then
+        COUNT=$(jq -r 'if type=="array" then length else (if has("findings") then .findings|length else 0 end) end' gitleaks.json)
+        echo "🔎 Findings: $COUNT"
+        LIMIT=200
+        echo -e "\n| Rule | File:Line | Commit | Link |"
+        echo "|------|------------|--------|------|"
 
-      if [ "$SCAN_MODE" = "diff" ]; then
-        BASE_SHA=$(git merge-base origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME HEAD || echo "")
-        if [ -z "$BASE_SHA" ]; then
-          echo "⚠️ Base SHA not found, falling back to full scan"
-          SCAN_MODE="full"
-        else
-          echo "▶ Running diff scan $BASE_SHA...HEAD"
-          gitleaks detect --no-banner \
-            --report-format json --report-path gitleaks.json \
-            -c gitleaks.toml --source . --log-opts "$BASE_SHA...HEAD"
+        jq -r '
+          def norm:
+            {
+              file: (.File // .file // .Target // .Location.File // ""),
+              line: (.StartLine // .Line // .Location.StartLine // 0),
+              rule: (.RuleID // .Rule // .Description // ""),
+              commit: (.Commit // .commit // "")
+            };
+          (if type=="object" and has("findings") then .findings
+           elif type=="array" then .
+           else [] end)[] | norm
+        ' gitleaks.json \
+        | head -n "$LIMIT" \
+        | jq -s -r '.[] | "| \(.rule) | \(.file):\(.line) | \(.commit[0:7]) | https://$CI_PROJECT_PATH/blob/\(.commit)/\(.file)#L\(.line) |"' || true
+
+        if (( COUNT > LIMIT )); then
+          echo "... and $((COUNT - LIMIT)) more (see gitleaks.json artifact)"
         fi
-      fi
-
-      if [ "$SCAN_MODE" = "full" ]; then
-        echo "▶ Running full scan"
-        gitleaks detect --no-banner \
-          --report-format json --report-path gitleaks.json \
-          -c gitleaks.toml --source .
-      fi
-
-      echo "📄 Report Summary"
-      if [ -f gitleaks.json ]; then
-        COUNT=$(jq 'if type=="array" then length else 0 end' gitleaks.json)
-        echo "Findings: $COUNT"
       else
-        echo "No report found"
+        echo "ℹ️ No gitleaks.json found"
       fi
+
+  after_script:
+    - rm -f /usr/local/bin/gitleaks gitleaks.tgz gitleaks.json || true
+
   artifacts:
     when: always
     paths:
       - gitleaks.json
-    expire_in: 1 week
-  after_script:
-    - |
-      # Cleanup temporary files; keep gitleaks.json for artifact collection
-      rm -f /usr/local/bin/gitleaks 2>/dev/null || true
-      rm -f ./gitleaks 2>/dev/null || true
-      rm -f gitleaks.tgz 2>/dev/null || true
-  allow_failure: true
+
+  allow_failure: false
 
 gitleaks_diff:
   extends: .gitleaks_scan
-  tags:
-    - tfprod-distributed-werf
   variables:
     SCAN_MODE: "diff"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
 
-gitleaks_full:
+gitleaks_full_manual:
   extends: .gitleaks_scan
-  tags:
-    - tfprod-distributed-werf
   variables:
     SCAN_MODE: "full"
   rules:
     - if: '$CI_PIPELINE_SOURCE == "web"'
+
+gitleaks_full_scheduled:
+  extends: .gitleaks_scan
+  variables:
+    SCAN_MODE: "full"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'


### PR DESCRIPTION
### What's added:
- New `gitleaks.gitlab-ci.yml` template for automatic secret detection in code
- Support for two scan modes: `diff` (PR changes only) and `full` (entire repository)
- Automatic Gitleaks v8.28.0 installation with Linux x64/ARM64 support
- GitLab CI integration via three jobs:
  - `gitleaks_diff` - for MRs (automatic)
  - `gitleaks_full_manual` - for manual runs
  - `gitleaks_full_scheduled` - for scheduled scans
- Custom configuration support via `gitleaks.toml`
- Detailed results output with links to problematic code locations
- JSON report artifacts for further analysis

### Usage:
```yaml
include:
  - remote: 'https://raw.githubusercontent.com/deckhouse/modules-gitlab-ci/refs/heads/main/templates/gitleaks.gitlab-ci.yml'
```

This template complements the existing Deckhouse CI template ecosystem, providing additional security for module development.
```