### PR TITLE
[templates] Add Go_Checks with coverage and toolchain fixes (backport from v11.0)

### DIFF
--- a/scripts/go_test_coverage.sh
+++ b/scripts/go_test_coverage.sh
@@ -14,8 +14,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Fix covdata tool lookup with Go 1.25 toolchain switching
+# Force the toolchain selected by `go.mod` to be downloaded for every module
+# we touch. The runner ships a Go distribution (longsleep PPA on Ubuntu) that
+# strips `covdata` and several other tools from `$GOROOT/pkg/tool/...`. Plain
+# `GOTOOLCHAIN=auto` keeps such a stripped local toolchain whenever it
+# satisfies the `go` directive, and `go test ... -cover` then fails with
+# `go: no such tool "covdata"` for packages that have no `*_test.go` files.
+# Setting GOTOOLCHAIN=goX.Y.Z (without the `+auto` suffix) makes the `go`
+# command always fetch the official upstream toolchain, which includes
+# `covdata`. The downloaded archive is cached under
+# `$GOMODCACHE/golang.org/toolchain` and reused by subsequent jobs.
 export GOTOOLCHAIN=auto
+
+# Print a GOTOOLCHAIN value (e.g. goX.Y.Z) derived from the `go` directive
+# in the given go.mod, or empty if no usable version can be parsed.
+mod_go_toolchain() {
+    local gomod="$1"
+    local v
+    v=$(awk '$1 == "go" && $2 ~ /^[0-9]+\.[0-9]+(\.[0-9]+)?$/ {print $2; exit}' "$gomod")
+    if [ -z "$v" ]; then
+        return
+    fi
+    case "$v" in
+        *.*.*) ;;
+        *) v="${v}.0" ;;
+    esac
+    printf 'go%s\n' "$v"
+}
 
 if [ ! -d "images" ]; then
     echo "No images/ directory found. Please run this script from the root of the repository."
@@ -24,18 +49,27 @@ fi
 
 find images/ -type f -name "go.mod" | while read -r gomod; do
     dir=$(dirname "$gomod")
-    
+
     echo "Test coverage in $dir"
-    
+
     cd "$dir" || continue
-    
+
+    toolchain=$(mod_go_toolchain go.mod)
+    if [ -n "$toolchain" ]; then
+        export GOTOOLCHAIN="$toolchain"
+        echo "  Using GOTOOLCHAIN=$toolchain (forced download to get a complete Go SDK with 'covdata')"
+    else
+        export GOTOOLCHAIN=auto
+        echo "  Could not parse 'go' directive from $dir/go.mod; falling back to GOTOOLCHAIN=auto"
+    fi
+
     for tag in $GO_BUILD_TAGS; do
         echo "  Build tag: $tag"
-        
-        go test ./... -cover -tags "$tag" 
+
+        go test ./... -cover -tags "$tag"
     done
-    
+
     cd - > /dev/null
-    
+
     echo "----------------------------------------"
 done

--- a/templates/Go_Checks.gitlab-ci.yml
+++ b/templates/Go_Checks.gitlab-ci.yml
@@ -1,0 +1,333 @@
+# Go checks: linter, tests, test coverage, modules check.
+#
+# Hidden jobs to be extended by consuming projects.
+# Each job expects:
+#   - GO_BUILD_TAGS variable (space-separated list of build tags / editions)
+#   - `go` available in $PATH
+#
+# Example usage in a project:
+#
+#   include:
+#     - project: "deckhouse/3p/deckhouse/modules-gitlab-ci"
+#       ref: "v13.0"
+#       file:
+#         - "/templates/Go_Checks.gitlab-ci.yml"
+#
+#   go_linter_dev:
+#     extends:
+#       - .go_linter
+#       - .dev
+
+# ---------------------------------------------------------------------------
+# Linter
+# ---------------------------------------------------------------------------
+.go_linter:
+  stage: go_checks
+  allow_failure: true
+  script:
+    - |
+      unique_index=0
+      section_start() {
+        local section_title="${1}"
+        local section_description="${2}"
+        if [ "$GITLAB_CI" == "true" ]; then
+          unique_index=$((unique_index + 1))
+          echo -e "section_start:$(date +%s):${section_title}_${unique_index}[collapsed=true]\r\e[0K${section_description}"
+        else
+          echo "$section_description"
+        fi
+      }
+      section_end() {
+        local section_title="${1}"
+        if [ "$GITLAB_CI" == "true" ]; then
+          echo -e "section_end:$(date +%s):${section_title}_${unique_index}\r\e[0K"
+        fi
+      }
+
+      linter_version="v2.9.0"
+      section_start "install_linter" "Installing golangci-lint@$linter_version"
+      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b . $linter_version
+      section_end "install_linter"
+
+      for config in .golangci.yaml .golangci.yml; do
+        if [ -f "$config" ] && ! grep -q 'version:.*"2"' "$config" 2>/dev/null; then
+          echo "Migrating $config to golangci-lint v2 format..."
+          ./golangci-lint migrate -c "$config" --skip-validation 2>/dev/null || true
+        fi
+      done
+
+      basedir=$(pwd)
+      failed='false'
+
+      run_linters() {
+        local run_for="${1}"
+        local extra_args="${2}"
+        for i in $(find images -type f -name go.mod); do
+          dir=$(echo $i | sed 's/go.mod$//')
+          cd $basedir/$dir
+          for edition in $GO_BUILD_TAGS; do
+            section_start "run_lint" "Running linter in $dir (edition: $edition) for $run_for"
+            ../../golangci-lint run ${extra_args} --fix --color=always --allow-parallel-runners --build-tags $edition
+            local linter_status=$?
+            section_end "run_lint"
+            if [ $linter_status -ne 0 ]; then
+              echo -e "\e[31mLinter FAILED in $dir (edition: $edition) for $run_for\e[0m"
+              failed='true'
+            else
+              echo -e "\e[32mLinter PASSED in $dir (edition: $edition) for $run_for\e[0m"
+            fi
+          done
+          cd - > /dev/null
+        done
+
+        if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
+          echo -e "\e[31mLinter requests changes for $run_for\e[0m"
+          section_start "print_patch" "To apply these changes run"
+          echo "git apply - <<EOF
+      $(git diff)
+      EOF"
+          section_end "print_patch"
+          git checkout -f
+          failed='true'
+        else
+          echo -e "\e[32mLinter doesn't have changes requested for $run_for\e[0m"
+        fi
+      }
+
+      if [ -n "${CI_MERGE_REQUEST_DIFF_BASE_SHA}" ]; then
+        run_linters "modified files" "--new-from-merge-base=${CI_MERGE_REQUEST_DIFF_BASE_SHA}"
+      fi
+
+      run_linters "all files"
+
+      rm golangci-lint
+
+      if [ $failed == 'true' ]; then
+        exit 1
+      fi
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+.go_tests:
+  stage: go_checks
+  allow_failure: true
+  script:
+    - |
+      basedir=$(pwd)
+      failed='false'
+
+      # Force the toolchain selected by go.mod to be downloaded; see the long
+      # comment in `.go_test_coverage` below. Even without `-cover`, anything
+      # that ends up calling stripped tools (e.g. `addr2line`, `pprof`,
+      # `test2json`) will break against the longsleep PPA Go on the runner,
+      # so we keep behaviour consistent with the coverage job.
+      export GOTOOLCHAIN=auto
+
+      mod_go_toolchain() {
+        local gomod="$1"
+        local v
+        v=$(awk '$1 == "go" && $2 ~ /^[0-9]+\.[0-9]+(\.[0-9]+)?$/ {print $2; exit}' "$gomod")
+        if [ -z "$v" ]; then
+          return
+        fi
+        case "$v" in
+          *.*.*) ;;
+          *) v="${v}.0" ;;
+        esac
+        printf 'go%s\n' "$v"
+      }
+
+      # Find the nearest go.mod walking up from $1. Prints its path or empty.
+      find_gomod_for() {
+        local d="$1"
+        while [ -n "$d" ] && [ "$d" != "/" ] && [ "$d" != "." ]; do
+          if [ -f "$d/go.mod" ]; then
+            printf '%s\n' "$d/go.mod"
+            return
+          fi
+          d=$(dirname "$d")
+        done
+      }
+
+      for i in $(find images -type f -name '*_test.go'); do
+        dir=$(echo $i | sed 's/[a-z_A-Z0-9-]*_test.go$//')
+        cd $basedir/$dir
+
+        gomod=$(find_gomod_for "$basedir/$dir")
+        if [ -n "$gomod" ]; then
+          toolchain=$(mod_go_toolchain "$gomod")
+          if [ -n "$toolchain" ]; then
+            export GOTOOLCHAIN="$toolchain"
+          else
+            export GOTOOLCHAIN=auto
+          fi
+        else
+          export GOTOOLCHAIN=auto
+        fi
+
+        for edition in $GO_BUILD_TAGS; do
+          echo "Running tests in $dir (edition: $edition, GOTOOLCHAIN=$GOTOOLCHAIN)"
+          go test -v -tags $edition
+          if [ $? -ne 0 ]; then
+            echo "Tests failed in $dir (edition: $edition)"
+            failed='true'
+          fi
+        done
+      done
+
+      if [ $failed == 'true' ]; then
+        exit 1
+      fi
+
+# ---------------------------------------------------------------------------
+# Test coverage
+# ---------------------------------------------------------------------------
+.go_test_coverage:
+  stage: go_checks
+  allow_failure: true
+  script:
+    - |
+      # Force the toolchain selected by `go.mod` to be downloaded for every
+      # module we touch. The runner ships a Go distribution (longsleep PPA
+      # on Ubuntu) that strips `covdata` and several other tools from
+      # `$GOROOT/pkg/tool/...`. Plain `GOTOOLCHAIN=auto` keeps such a
+      # stripped local toolchain whenever it satisfies the `go` directive,
+      # and `go test ... -cover` then fails with `go: no such tool
+      # "covdata"` for packages that have no `*_test.go` files. Setting
+      # GOTOOLCHAIN=goX.Y.Z (without the `+auto` suffix) makes the `go`
+      # command always fetch the official upstream toolchain, which
+      # includes `covdata`. The downloaded archive is cached under
+      # `$GOMODCACHE/golang.org/toolchain` and reused by subsequent jobs.
+      export GOTOOLCHAIN=auto
+
+      mod_go_toolchain() {
+        local gomod="$1"
+        local v
+        v=$(awk '$1 == "go" && $2 ~ /^[0-9]+\.[0-9]+(\.[0-9]+)?$/ {print $2; exit}' "$gomod")
+        if [ -z "$v" ]; then
+          return
+        fi
+        case "$v" in
+          *.*.*) ;;
+          *) v="${v}.0" ;;
+        esac
+        printf 'go%s\n' "$v"
+      }
+
+      if [ ! -d "images" ]; then
+        echo "No images/ directory found. Please run this script from the root of the repository."
+        exit 1
+      fi
+
+      find images/ -type f -name "go.mod" | while read -r gomod; do
+        dir=$(dirname "$gomod")
+
+        echo "Test coverage in $dir"
+
+        cd "$dir" || continue
+
+        toolchain=$(mod_go_toolchain go.mod)
+        if [ -n "$toolchain" ]; then
+          export GOTOOLCHAIN="$toolchain"
+          echo "  Using GOTOOLCHAIN=$toolchain (forced download to get a complete Go SDK with 'covdata')"
+        else
+          export GOTOOLCHAIN=auto
+          echo "  Could not parse 'go' directive from $dir/go.mod; falling back to GOTOOLCHAIN=auto"
+        fi
+
+        for tag in $GO_BUILD_TAGS; do
+          echo "  Build tag: $tag"
+          go test ./... -cover -tags "$tag"
+        done
+
+        cd - > /dev/null
+
+        echo "----------------------------------------"
+      done
+
+# ---------------------------------------------------------------------------
+# Go modules check
+# ---------------------------------------------------------------------------
+.go_modules_check:
+  stage: go_checks
+  allow_failure: true
+  script:
+    - |
+      search_dir=$(pwd)"/images"
+
+      if [ ! -d "$search_dir" ]; then
+        echo "Directory $search_dir does not exist."
+        exit 1
+      fi
+
+      temp_dir=$(mktemp -d)
+      touch "$temp_dir/incorrect_alert"
+
+      trap 'rm -rf "$temp_dir"' EXIT
+
+      find images/ -type f -name "go.mod" | while read -r gomod; do
+        dir=$(dirname "$gomod")
+
+        echo "Checking $dir"
+
+        cd "$dir" || continue
+
+        go list -m all | grep deckhouse | grep -v '=>' | while IFS= read -r line; do
+          module_name=$(echo "$line" | awk '{print $1}')
+          module_version=$(echo "$line" | awk '{print $2}')
+
+          if [ -z "$module_version" ]; then
+            echo "  Checking module name $module_name"
+            GITLAB_REPOSITORY=$(echo "$CI_REPOSITORY_URL" | sed 's/.*@//' | sed 's/\.git$//')
+            correct_module_name="$GITLAB_REPOSITORY"/"$dir"
+            if [ "$module_name" != "$correct_module_name" ]; then
+              echo "  Incorrect module name: $module_name, expected: $correct_module_name"
+              echo "  Incorrect module name: $module_name, expected: $correct_module_name" >> "$temp_dir/incorrect_alert"
+            else
+              echo "  Correct module name: $module_name"
+            fi
+          else
+            echo "  Checking module tag $module_name"
+            repository=$(echo "$line" | awk '{print $1}' | awk -F'/' '{ print "https://"$1"/"$2"/"$3".git" }')
+            pseudo_tag=$(echo "$line" | awk '{print $2}')
+            if [[ $pseudo_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "  Exact tag in repo $repository: $pseudo_tag, skipping"
+              continue
+            fi
+
+            echo "  Cloning repo $repository into $temp_dir"
+            if [ ! -d "$temp_dir/$repository" ]; then
+              git clone "$repository" "$temp_dir/$repository" >/dev/null 2>&1
+            fi
+
+            cd "$temp_dir/$repository" || continue
+
+            commit_info=$(git log -1 --pretty=format:"%H %cd" --date=iso-strict -- api/*)
+            short_hash=$(echo "$commit_info" | awk '{print substr($1,1,12)}')
+            commit_date=$(echo "$commit_info" | awk '{print $2}')
+            commit_date=$(date -u -d "$commit_date" +"%Y%m%d%H%M%S")
+            actual_pseudo_tag="v0.0.0-"$commit_date"-"$short_hash
+            pseudo_tag_date=$(echo $pseudo_tag | awk -F'-' '{ print $2 }')
+            echo "  Latest commit in $repository: $short_hash $commit_date"
+
+            if [[ "$pseudo_tag" != "$actual_pseudo_tag" ]]; then
+              echo "  Incorrect pseudo tag for repo $repository in file $go_mod_file (current: $pseudo_tag, actual: $actual_pseudo_tag)"
+              echo "  Incorrect pseudo tag for repo $repository in file $go_mod_file (current: $pseudo_tag, actual: $actual_pseudo_tag)" >> "$temp_dir/incorrect_alert"
+            fi
+
+            cd - >/dev/null 2>&1
+          fi
+        done
+
+        cd - > /dev/null
+
+        echo "----------------------------------------"
+      done
+
+      alert_lines_count=$(cat "$temp_dir/incorrect_alert" | wc -l)
+
+      if [ $alert_lines_count != 0 ]; then
+        echo "We have non-actual pseudo-tags or modules names in repository's go.mod files"
+        exit 1
+      fi


### PR DESCRIPTION
## Summary

Backport from `v11.0` of reusable Go CI jobs and related fixes (already landed in `v12.0`):

- Add `templates/Go_Checks.gitlab-ci.yml` with reusable Go check jobs (`.go_tests`, `.go_test_coverage`, etc.).
- Install `covdata` tool in `go_test_coverage` job, then drop the bogus `go install cmd/covdata@latest` (covdata is a toolchain tool, not a module package).
- Force download of `go.mod` toolchain in Go test jobs. The CI runner ships a stripped Go distribution that omits `covdata` and several other tools from `$GOROOT/pkg/tool/...`; parse the `go` directive of each module's `go.mod` and export `GOTOOLCHAIN=goX.Y.Z` (without `+auto`) before invoking `go test` so the official upstream toolchain is fetched under `$GOMODCACHE/golang.org/toolchain`.

Squashed cherry-pick of the following `v11.0` commits:

- `5062f79` [templates] Add Go_Checks.gitlab-ci.yml with reusable Go check jobs
- `2f02ff3` [templates] Install covdata tool in go_test_coverage job
- `97600a8` [templates] Drop bogus `go install cmd/covdata@latest` from go_test_coverage
- `911b26c` [templates] Force download of go.mod toolchain in Go test jobs

## Test plan

- [ ] Verify `.go_test_coverage` job passes in a downstream module that consumes the template
- [ ] Verify `.go_tests` job passes in a downstream module with multiple `go.mod` files
- [ ] Confirm `covdata` tool is available via the downloaded toolchain