### PR TITLE
[templates] Fix Merge_Release and Translate_Changelog on shell executors

### DIFF
--- a/scripts/get_changelog.py
+++ b/scripts/get_changelog.py
@@ -354,6 +354,7 @@ def main():
         'https://github.com/deckhouse/csi-ceph',
         'https://github.com/deckhouse/snapshot-controller',
         'https://github.com/deckhouse/state-snapshotter',
+        'https://github.com/deckhouse/storage-foundation',
         'https://fox.flant.com/deckhouse/storage/csi-yadro-tatlin-unified',
         'https://fox.flant.com/deckhouse/storage/csi-netapp',
         'https://fox.flant.com/deckhouse/storage/csi-hpe',

--- a/templates/Merge_Release.gitlab-ci.yml
+++ b/templates/Merge_Release.gitlab-ci.yml
@@ -27,7 +27,20 @@
       when: on_success
     - when: never
   before_script:
-    - apt-get update -qq && apt-get install -y -qq git curl jq
+    - |
+      set -e
+      missing=""
+      for bin in git curl jq; do
+        command -v "$bin" >/dev/null 2>&1 || missing="$missing $bin"
+      done
+      if [ -n "$missing" ]; then
+        if [ "$(id -u)" = "0" ]; then
+          apt-get update -qq && apt-get install -y -qq $missing
+        else
+          echo "Missing required tools:$missing. Install them on the runner host (shell executor has no root)." >&2
+          exit 1
+        fi
+      fi
   script:
     - |
       set -euo pipefail
@@ -46,11 +59,12 @@
       echo "MR merged successfully."
       sleep 10
       # Clone base branch (post-merge), tag, push
-      git config --global user.email "gitlab-ci@gitlab.com"
-      git config --global user.name "GitLab CI"
       REPO_URL="https://oauth2:${RELEASE_TOKEN:-$CI_JOB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
       git clone --branch "${MERGE_RELEASE_BASE_BRANCH}" --single-branch --depth 50 "$REPO_URL" "$REPO_DIR"
       cd "$REPO_DIR"
+      # Use local (repo-scoped) git config to avoid writing to $HOME on shell executors.
+      git config user.email "gitlab-ci@gitlab.com"
+      git config user.name "GitLab CI"
       git fetch origin "${MERGE_RELEASE_BASE_BRANCH}"
       git reset --hard "origin/${MERGE_RELEASE_BASE_BRANCH}"
       if ! git rev-parse "$VERSION" >/dev/null 2>&1; then

--- a/templates/Translate_Changelog.gitlab-ci.yml
+++ b/templates/Translate_Changelog.gitlab-ci.yml
@@ -19,11 +19,25 @@
   rules:
     - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
   before_script:
-    - apt-get update -qq && apt-get install -y -qq git curl jq
+    - |
+      set -e
+      missing=""
+      for bin in git curl jq python3; do
+        command -v "$bin" >/dev/null 2>&1 || missing="$missing $bin"
+      done
+      if [ -n "$missing" ]; then
+        if [ "$(id -u)" = "0" ]; then
+          apt-get update -qq && apt-get install -y -qq $missing
+        else
+          echo "Missing required tools:$missing. Install them on the runner host (shell executor has no root)." >&2
+          exit 1
+        fi
+      fi
     - python3 -m venv /tmp/venv
     - /tmp/venv/bin/pip install --no-cache-dir deep-translator packaging
-    - git config user.email "gitlab-ci@gitlab.com"
-    - git config user.name "GitLab CI"
+    # Use local (repo-scoped) git config to avoid writing to $HOME on shell executors.
+    - git -C "${CI_PROJECT_DIR}" config user.email "gitlab-ci@gitlab.com"
+    - git -C "${CI_PROJECT_DIR}" config user.name "GitLab CI"
   script:
     - |
       set -euo pipefail


### PR DESCRIPTION
## Summary

Both `templates/Merge_Release.gitlab-ci.yml` and `templates/Translate_Changelog.gitlab-ci.yml` fail on GitLab runners that use the **shell executor** because the templates assume root/docker semantics:

- `apt-get install` requires root, which shell executors do not have (`Permission denied` on `/var/lib/apt/lists/lock`).
- `git config --global` writes to the runner user's `$HOME` (e.g. `/opt/gitlab-runner/.gitconfig`), which is typically not writable (`could not lock config file /opt/gitlab-runner/.gitconfig: Permission denied`).

Real log excerpt from a failing `merge_and_release` job on a shell runner:

```
$ apt-get update -qq && apt-get install -y -qq git curl jq
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
...
MR merged successfully.
error: could not lock config file /opt/gitlab-runner/.gitconfig: Permission denied
ERROR: Job failed: exit status 1
```

Note that the `image:` directive in the templates is silently ignored by shell executors, so the job runs directly on the host as the `gitlab-runner` user.

## Changes

- Replace the unconditional `apt-get install` with a `command -v` presence check. Install only when the tool is actually missing *and* the job runs as root (typical for docker images). On shell executors the required tools (`git`, `curl`, `jq`, `python3`) are expected to be preinstalled on the host, and the job now fails fast with a clear message instead of a cryptic apt error.
- Drop `git config --global`. Use repo-local `git config` inside the clone directory (`Merge_Release`) or `git -C "$CI_PROJECT_DIR" config` (`Translate_Changelog`) so nothing is written to `$HOME`.

The templates continue to work on both docker and shell executors with no runner-side changes beyond having the standard tooling available on the host.

## Backport

Cherry-picked to `v12.0` in 1c614a3.

## Test plan

- [ ] Run `merge_and_release` job on a shell-executor runner with `git`, `curl`, `jq` preinstalled and confirm it tags and creates a Release without touching `$HOME` or `apt`.
- [ ] Run `translate_and_create_mr` job on a shell-executor runner and confirm the translation MR is created.
- [ ] Run both jobs on a docker runner (e.g. `debian:bookworm-slim`, `python:3.11-slim`) and confirm `apt-get install` still works for any missing tool.
- [ ] Re-run the `storage-volume-data-manager` MR pipeline that previously failed and confirm the job succeeds.