### PR TITLE
[scripts] Deduplicate go_tests runs per module

### DIFF
--- a/scripts/go_tests.sh
+++ b/scripts/go_tests.sh
@@ -17,20 +17,26 @@
 basedir=$(pwd)
 failed='false'
 
-for i in $(find images -type f -name '*_test.go');do
-    dir=$(echo $i | sed 's/[a-z_A-Z0-9-]*_test.go$//')
-    cd $basedir/$dir
+# Iterate over Go modules (one go.mod per module) instead of every *_test.go
+# file. The previous implementation ran `go test` once per test file in the
+# enclosing package, which produced N*M duplicate runs for a package with N
+# test files and M build tags. Iterating over go.mod files runs each module
+# exactly once per build tag, and `./...` covers every package inside.
+for gomod in $(find images -type f -name 'go.mod'); do
+    dir=$(dirname "$gomod")
+    cd "$basedir/$dir" || continue
     # check all editions
-    for edition in $GO_BUILD_TAGS ;do
+    for edition in $GO_BUILD_TAGS; do
         echo "Running tests in $dir (edition: $edition)"
-        go test -v -tags $edition
+        go test -v -tags "$edition" ./...
         if [ $? -ne 0 ]; then
-        echo "Tests failed in $dir (edition: $edition)"
-        failed='true'
+            echo "Tests failed in $dir (edition: $edition)"
+            failed='true'
         fi
     done
+    cd "$basedir" || exit 1
 done
 
-if [ $failed == 'true' ]; then
+if [ "$failed" = 'true' ]; then
     exit 1
 fi


### PR DESCRIPTION
## Summary

`scripts/go_tests.sh` previously iterated over every `*_test.go` file under `images/` and ran `go test` in the enclosing directory without specifying a package or file. For a package with N test files and M build tags, this produced **N*M** runs of the same package instead of M.

This PR switches the outer loop to iterate over `go.mod` files (one per Go module) and runs `go test ./... -tags <tag>` once per module per build tag. The pattern matches what is already used in:

- `scripts/go_linter.sh`
- `scripts/go_modules_check.sh`
- `scripts/go_test_coverage.sh`

Additional small improvements:

- restore the working directory between modules (use `cd "$basedir"` instead of letting it drift),
- use `dirname` instead of a fragile `sed` regex on the file name,
- quote variables and use `[ "$failed" = 'true' ]` for portability.

The same fix has already been applied to the `v12.0` branch.

## Test plan

- [ ] Trigger a Go test job in a downstream project that uses this template.
- [ ] Confirm in the job log that each Go module is tested **once per build tag** (no more duplicate runs per test file).
- [ ] Verify failing tests still cause the job to exit with non-zero status.
