### PR TITLE
Vex attestations

### DIFF
--- a/templates/Build.gitlab-ci.yml
+++ b/templates/Build.gitlab-ci.yml
@@ -43,11 +43,22 @@ variables:
 
     # Bundle image
     - |
-      IMAGE_SRC="$(jq -r '.Images."bundle".DockerImageName' images_tags_werf.json)"
-      IMAGE_DST="$(jq -r '.Images.bundle.DockerRepo' images_tags_werf.json):${MODULES_MODULE_TAG}"
+      IMAGE_REPO="$(jq -r '.Images.bundle.DockerRepo' images_tags_werf.json)"
+      IMAGE_SRC="$(jq -r '.Images.bundle.DockerImageName' images_tags_werf.json)"
+      IMAGE_DST="${IMAGE_REPO}:${MODULES_MODULE_TAG}"
 
-      echo "✨ Pushing ${IMAGE_SRC} to ${IMAGE_DST}"
+      echo "✨ Bundle image : Pushing ${IMAGE_SRC} to ${IMAGE_DST}"
       crane copy ${IMAGE_SRC} ${IMAGE_DST}
+
+      # Copying attestation for bundle
+      IMAGE_DIGEST="$(jq -r ".Images.bundle.DockerImageDigest" images_tags_werf.json)"
+      IMAGE_DIGEST="${IMAGE_DIGEST#sha256:}"
+      if (crane manifest "${IMAGE_REPO}:sha256-${IMAGE_DIGEST}.att" > /dev/null 2>&1); then
+        echo "✨ [$(date -u)] Copying 'bundle' attestation"
+        crane copy "${IMAGE_REPO}:sha256-${IMAGE_DIGEST}.att" "${IMAGE_REPO}:sha256-${IMAGE_DIGEST}.att"
+      else
+        echo "✨ [$(date -u)] Attestation for 'bundle' not found, skipping..."
+      fi
     # Release-channel image
     - |
       IMAGE_SRC="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"


### PR DESCRIPTION
**`templates/Build.gitlab-ci.yml` — Bundle image VEX attestation copying**

The `.build` job now automatically detects and copies cosign/VEX attestation manifests for the `bundle` image when pushing to the destination registry.

- Extracts `IMAGE_REPO` as a dedicated variable for consistent reuse.
- After `crane copy` for the bundle image, checks whether an attestation tag (`sha256-<digest>.att`) exists in the source repository.
- If found → copies the attestation to the destination registry.
- If not found → logs a skip message and continues without error.

This ensures that supply chain attestations travel with the `bundle` image and remain verifiable in the destination registry.
