### PR TITLE
refactor(templates): split rules-free base bodies for build/deploy/lint

### DIFF
--- a/templates/Build.gitlab-ci.yml
+++ b/templates/Build.gitlab-ci.yml
@@ -17,17 +17,26 @@ variables:
       - "true"
       - "false"
 
-.lint:
+# `.lint_base` holds the body only (no `rules:`) so consuming projects can add
+# their own gating via a context mixin, e.g. `extends: [.lint_base, .dev]`, the
+# same convention as `.go_linter` / `.cve_scan`. `.lint` keeps the previous
+# behavior (fires on any branch/tag) for existing consumers.
+.lint_base:
   stage: build
   script:
     - |
       dmt lint ./
+  allow_failure: true
+
+.lint:
+  extends: .lint_base
   rules:
     - if: $CI_COMMIT_BRANCH
     - if: $CI_COMMIT_TAG
-  allow_failure: true
 
-.build:
+# `.build_base` holds the body only (no `rules:`); see `.lint_base` above.
+# `.build` re-adds the default any-branch/tag gating for existing consumers.
+.build_base:
   stage: build
   script:
     # Use gitlab ci job token
@@ -73,6 +82,9 @@ variables:
         --oci-empty-base \
         --new_layer "" \
         --new_tag "${MODULES_MODULE_SOURCE}:${MODULES_MODULE_NAME}"
+
+.build:
+  extends: .build_base
   rules:
     - if: $CI_COMMIT_BRANCH
     - if: $CI_COMMIT_TAG

--- a/templates/Deploy.gitlab-ci.yml
+++ b/templates/Deploy.gitlab-ci.yml
@@ -4,7 +4,12 @@
 #   $RELEASE_CHANNEL - lowercase release channel name, e.g., alpha, stable, early-access
 
 
-.deploy:
+# `.deploy_base` holds the body only (no `rules:` / `when:`) so consuming
+# projects can drive gating from their own context mixin, e.g.
+# `extends: [.deploy_base, .prod_manual]`, matching the `.go_linter` /
+# `.cve_scan` convention. `.deploy` keeps the previous behavior (manual, on
+# tag) for existing consumers.
+.deploy_base:
   stage: deploy
   script:
   - |
@@ -15,6 +20,9 @@
 
     echo "✨ Pushing ${IMAGE_SRC} to ${IMAGE_DST}"
     crane copy "${IMAGE_SRC}" "${IMAGE_DST}"
+
+.deploy:
+  extends: .deploy_base
   rules:
     - if: $CI_COMMIT_TAG
   when: manual


### PR DESCRIPTION
## What

Split the three rules-baked hidden templates into a rules-free `*_base` body plus a thin wrapper that re-adds the rules:

- `.build`  → `.build_base` (body) + `.build` (`extends: .build_base` + rules)
- `.deploy` → `.deploy_base` (body) + `.deploy` (extends + rules + `when: manual`)
- `.lint`   → `.lint_base` (body + `allow_failure`) + `.lint` (extends + rules)

## Why

`.build` / `.deploy` / `.lint` bake `rules:` directly into the job body. GitLab merges `extends:` rules parent-first, so a consuming project cannot override the inherited gating — it is forced to copy the whole body verbatim just to attach its own `rules:` (e.g. strict `.dev` / `.main` / `.prod` gating). Those verbatim copies then drift from upstream (the `virtualization` module's copy already predates the bundle-attestation change).

Every other body template in this repo (`.go_linter`, `.go_tests`, `.cve_scan`, `.svace_analyze`) is already rules-free and expects the consumer to attach a context mixin, e.g. `extends: [.go_linter, .dev]`. These three were the outliers; this change aligns them.

## Backward compatibility

`.build` / `.deploy` / `.lint` resolve to byte-identical jobs after the split, so existing consumers (including `examples/simple-module.gitlab-ci.yml` and the README snippet) are unaffected. New consumers can now do:

```yaml
build_dev:
  extends:
    - .build_base
    - .dev
```
