### PR TITLE
fix(gitleaks): compose the centralized and module configs instead of choosing one

### DIFF
--- a/templates/gitleaks.gitlab-ci.yml
+++ b/templates/gitleaks.gitlab-ci.yml
@@ -45,24 +45,41 @@ variables:
         exit 1
       fi
       
-      # ========== Check for optional local config ==========
+      # ========== Compose the scan config ==========
+      # A module's .gitleaks.toml must extend the centralized config, not replace it.
+      # Gitleaks chains configs through [extend] path, so drop the module's own [extend]
+      # section, point a fresh one at the config downloaded above, and keep the rest of the
+      # module config verbatim. Resulting chain:
+      #   gitleaks defaults <- centralized base config <- module config
+      # The module config stays standalone-valid, so `gitleaks detect` still works locally.
+      MERGED_CONFIG="/tmp/gitleaks.merged.toml"
       if [[ -f ".gitleaks.toml" ]]; then
-        # Local config exists - check if it has [extend] section
-        if grep -q "^\[extend\]" .gitleaks.toml; then
-          # Has extend section - use as is
-          CONFIG_ARG="-c .gitleaks.toml"
-          echo "✅ Found local config with [extend] section - using as is"
-        else
-          # No extend section - warn and ignore, use base config only
-          echo "⚠️  WARNING: Local config file .gitleaks.toml exists but does not contain [extend] section"
-          echo "   We cannot be sure this is the expected extend configuration."
-          echo "   Ignoring local config file and using base config only."
-          CONFIG_ARG="-c $TMP_BASE_CONFIG"
+        MODULE_EXTEND_PATH="$(awk '
+          /^[[:space:]]*\[extend\]/ { in_extend = 1; next }
+          /^[[:space:]]*\[/         { in_extend = 0 }
+          in_extend && /^[[:space:]]*path[[:space:]]*=/ { print }
+        ' .gitleaks.toml)"
+        if [[ -n "$MODULE_EXTEND_PATH" ]]; then
+          echo "⚠️  WARNING: .gitleaks.toml declares its own [extend] path:"
+          echo "     $MODULE_EXTEND_PATH"
+          echo "   It is replaced by the centralized config."
         fi
+
+        {
+          printf '[extend]\nuseDefault = false\npath = "%s"\n\n' "$TMP_BASE_CONFIG"
+          awk '
+            /^[[:space:]]*\[extend\]/ { skip = 1; next }
+            /^[[:space:]]*\[/         { skip = 0 }
+            !skip
+          ' .gitleaks.toml
+        } > "$MERGED_CONFIG"
+
+        CONFIG_ARG="-c $MERGED_CONFIG"
+        echo "✅ Composed centralized config + module .gitleaks.toml into $MERGED_CONFIG"
       else
-        # No local config - use centralized config only
+        # No module config - use centralized config only
         CONFIG_ARG="-c $TMP_BASE_CONFIG"
-        echo "🔹 Using centralized config only (no local customization)"
+        echo "🔹 Using centralized config only (no module .gitleaks.toml)"
       fi
       
       # ========== Run scan ==========
@@ -129,7 +146,7 @@ variables:
 
   after_script:
     - echo "🧹 Cleaning up runner workspace..."
-    - rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz /tmp/gitleaks.base.toml || true
+    - rm -f "$HOME/.local/bin/gitleaks" gitleaks.tgz /tmp/gitleaks.base.toml /tmp/gitleaks.merged.toml || true
 
   artifacts:
     when: always


### PR DESCRIPTION
Closing — the CI does not need changing after all.

The choose-one logic in the gitleaks template is deliberate: the base config must stay ours, and a module that wants additions is expected to declare `[extend] useDefault = false` + `path = <base config>` and extend it rather than override it. That is exactly what the header of `gitleaks.base.toml` documents. My diagnosis attributed the outcome to the CI; the outcome is real, but the cause is that all 17 storage modules wrote `[extend] useDefault = true` with no `path`, i.e. they extend gitleaks' own defaults and never the centralized config. The modules are misconfigured, not the action.

Fixing them module-side gives the same result with no CI change. Verified on a repo holding a Vault token, a `.werf_secret_key`, an `h1:` checksum and a docs placeholder:

| Module config | Rules that fired |
|---|---|
| `useDefault = true` (today) | `generic-api-key` only |
| `useDefault = false` + `path` | `hashicorp-vault-token`, `werf-secret-key` |

In the second case `generic-api-key` also disappears, because the base allowlist suppresses the checksum — so the whole chain is live.

The differing base-config locations turned out not to be a blocker either. The GitHub and GitLab module sets are disjoint (no storage module has both `.github/workflows` and `.gitlab-ci.yml`), so each module only ever needs the path its own CI uses: `/tmp/gitleaks.base.toml` here, `gitleaks.base.toml` in modules-actions. My claim that no portable value exists was wrong.

The `v16.0` branch cut for this change is deleted.

## Two things worth fixing separately

1. **`grep -q "^\[extend\]"` cannot enforce the invariant it was written for.** It passes for `[extend] useDefault = true`, which extends gitleaks' defaults, not the centralized config — so it green-lights precisely the misconfiguration it was meant to catch. That is how 17 modules stayed silently unprotected. Worth replacing with a check that the declared `path` actually resolves to the base config, failing loudly otherwise.
2. **The two CI systems place the base config differently.** This template uses `/tmp/gitleaks.base.toml`; `modules-actions` has copied it to `./gitleaks.base.toml` since deckhouse/modules-actions#80. Harmless while the module sets stay disjoint, but it means a single `.gitleaks.toml` cannot serve both, and the two base configs document different paths in their headers.

The GitLab storage modules are being moved to `v15.0` (or kept on `v14.0` where they include `storage-e2e.gitlab-ci.yml`, which `v15.0` does not carry) with the module-side `.gitleaks.toml` fix, separately.
