### PR TITLE
fix(translate-changelog): do not fail the job when there is nothing to translate

### DIFF
--- a/templates/Translate_Changelog.gitlab-ci.yml
+++ b/templates/Translate_Changelog.gitlab-ci.yml
@@ -43,8 +43,9 @@
       set -euo pipefail
       export PATH="/tmp/venv/bin:$PATH"
       CHANGELOG_PATH="${TRANSLATE_CHANGELOG_PATH}"
-      # Check if last commit changed CHANGELOG/*.ru.yml
-      CHANGED=$(git show --name-only --pretty=format: HEAD | grep "^${CHANGELOG_PATH}/.*\.ru\.yml$" || true)
+      # Check if last commit added or modified CHANGELOG/*.ru.yml (--diff-filter=d skips deletions,
+      # which have nothing to translate — e.g. a revert that drops a release changelog)
+      CHANGED=$(git show --name-only --diff-filter=d --pretty=format: HEAD | grep "^${CHANGELOG_PATH}/.*\.ru\.yml$" || true)
       if [ -z "$CHANGED" ]; then
         echo "No CHANGELOG .ru.yml files changed in last commit, skipping."
         exit 0
@@ -109,8 +110,10 @@
       PYEOF
       ) || TRANSLATE_OUTPUT=""
       fi
-      # Parse VERSION from output; if missing, nothing was translated
-      VERSION=$(echo "$TRANSLATE_OUTPUT" | grep "^VERSION=" | cut -d= -f2)
+      # Parse VERSION from output; if missing, nothing was translated.
+      # `|| true` is required: under `set -o pipefail` a non-matching grep would fail the
+      # assignment and `set -e` would kill the job before the check below could run.
+      VERSION=$(echo "$TRANSLATE_OUTPUT" | grep "^VERSION=" | cut -d= -f2 || true)
       if [ -z "$VERSION" ]; then
         echo "No Russian changelog to translate (or English already exists)."
         exit 0


### PR DESCRIPTION
## What

Two fixes in `templates/Translate_Changelog.gitlab-ci.yml`:

1. **`VERSION=$(... | grep "^VERSION=" | cut -d= -f2)`** (line 113) runs under `set -euo pipefail`. When the translator produces no output, `grep` exits 1, `pipefail` propagates it, and `set -e` kills the job — so the `if [ -z "$VERSION" ]; then echo "No Russian changelog to translate"; exit 0; fi` branch immediately below is **unreachable**. Guarded with `|| true`.

2. The change detector (line 47) matched **deleted** files, so a commit that removes a release changelog was treated as work to do. Added `--diff-filter=d`.

## Why

Symptom: the job log ends right after `CHANGELOG .ru.yml files changed in last commit: <file>` with `ERROR: Job failed: exit status 1`. Hit in storage-volume-data-manager when a revert deleted `CHANGELOG/v0.2.0.ru.yml`. It never fires on normal changelog branches because those *add* a `.ru.yml` with no `.yml` yet, so `VERSION` is non-empty — which is why the dead branch went unnoticed.

## Verification

Extracted the shipped script block and ran it against a fixture repo:

| scenario | before | after |
|---|---|---|
| commit deletes `CHANGELOG/v0.2.0.ru.yml` | exit 1 | exit 0, `No CHANGELOG .ru.yml files changed in last commit, skipping.` |
| commit edits already-translated `CHANGELOG/v0.1.24.ru.yml` | exit 1 | exit 0, `No Russian changelog to translate (or English already exists).` |

Also confirmed `--diff-filter=d` still detects a genuinely added changelog (checked against the real `v0.1.24` changelog commit). The happy path is untouched.

## Note

The version branches consumed by the modules (`v14.0`/`v15.0`/`v16.0` on the fox mirror) carry the same bug and will need this cherry-picked to actually unblock them.