### PR TITLE
ci(go-linter): lint lib/go and e2e, not only images

### DIFF
--- a/scripts/go_linter.sh
+++ b/scripts/go_linter.sh
@@ -50,16 +50,44 @@ done
 basedir=$(pwd)
 failed='false'
 
+# go_module_roots prints the directories that may hold Go modules, skipping the
+# ones this repository does not have.
+#
+# images/ holds the buildable components. lib/go and e2e hold, respectively,
+# the packages those components share and the end-to-end suite; both are Go
+# modules in their own right, both are covered by the repository's .golangci
+# config, and neither was ever linted.
+go_module_roots() {
+    local root
+    for root in images lib/go e2e; do
+        if [ -d "$basedir/$root" ]; then
+            printf '%s\n' "$root"
+        fi
+    done
+}
+
 run_linters() {
     local run_for="${1}"
     local extra_args="${2}"
-    for i in $(find images -type f -name go.mod);do
+    local roots
+    roots=$(go_module_roots)
+    if [ -z "$roots" ]; then
+        echo "Nothing to lint: this repository has no images, lib/go or e2e directory"
+        return
+    fi
+    # Directories whose name starts with . or _ are invisible to the go tool,
+    # and a reused runner workspace leaves whole checkouts of other
+    # repositories in some of them (e2e/_storage-e2e is one), so the go.mod
+    # files under them are not ours to lint.
+    for i in $(find $roots \( -name '.*' -o -name '_*' \) -prune -o -type f -name go.mod -print);do
         dir=$(echo $i | sed 's/go.mod$//')
         cd $basedir/$dir
         # check all editions
         for edition in $GO_BUILD_TAGS ;do
             section_start "run_lint" "Running linter in $dir (edition: $edition) for $run_for"
-            ../../golangci-lint run ${extra_args} --fix --color=always --allow-parallel-runners --build-tags $edition
+            # Absolute path: the modules sit at different depths (images/x/,
+            # lib/go/x/, e2e/), so a relative one cannot reach the binary.
+            "$basedir/golangci-lint" run ${extra_args} --fix --color=always --allow-parallel-runners --build-tags $edition
             local linter_status=$?
             section_end "run_lint"
             if [ $linter_status -ne 0 ]; then

--- a/templates/Go_Checks.gitlab-ci.yml
+++ b/templates/Go_Checks.gitlab-ci.yml
@@ -59,15 +59,43 @@
       basedir=$(pwd)
       failed='false'
 
+      # go_module_roots prints the directories that may hold Go modules, skipping
+      # the ones this repository does not have.
+      #
+      # images/ holds the buildable components. lib/go and e2e hold,
+      # respectively, the packages those components share and the end-to-end
+      # suite; both are Go modules in their own right, both are covered by the
+      # repository's .golangci config, and neither was ever linted.
+      go_module_roots() {
+        local root
+        for root in images lib/go e2e; do
+          if [ -d "$basedir/$root" ]; then
+            printf '%s\n' "$root"
+          fi
+        done
+      }
+
       run_linters() {
         local run_for="${1}"
         local extra_args="${2}"
-        for i in $(find images -type f -name go.mod); do
+        local roots
+        roots=$(go_module_roots)
+        if [ -z "$roots" ]; then
+          echo "Nothing to lint: this repository has no images, lib/go or e2e directory"
+          return
+        fi
+        # Directories whose name starts with . or _ are invisible to the go
+        # tool, and a reused runner workspace leaves whole checkouts of other
+        # repositories in some of them (e2e/_storage-e2e is one), so the go.mod
+        # files under them are not ours to lint.
+        for i in $(find $roots \( -name '.*' -o -name '_*' \) -prune -o -type f -name go.mod -print); do
           dir=$(echo $i | sed 's/go.mod$//')
           cd $basedir/$dir
           for edition in $GO_BUILD_TAGS; do
             section_start "run_lint" "Running linter in $dir (edition: $edition) for $run_for"
-            ../../golangci-lint run ${extra_args} --fix --color=always --allow-parallel-runners --build-tags $edition
+            # Absolute path: the modules sit at different depths (images/x/,
+            # lib/go/x/, e2e/), so a relative one cannot reach the binary.
+            "$basedir/golangci-lint" run ${extra_args} --fix --color=always --allow-parallel-runners --build-tags $edition
             local linter_status=$?
             section_end "run_lint"
             if [ $linter_status -ne 0 ]; then


### PR DESCRIPTION
## Description

The go linter walked `find images -type f -name go.mod` and nothing else, so two kinds of Go module were never looked at: the packages under `lib/go` that the components share, and the `e2e` suite. Both are modules in their own right and both are already covered by the repository's `.golangci` config — which is what makes this easy to miss, since the config promises coverage the job never delivered.

The roots are probed before use, so a repository with only `images/` behaves exactly as before, and one with none of the three says so instead of failing on a `find` that has nothing to walk.

Two details the wider search forces:

- **The binary is addressed absolutely.** `../../golangci-lint` only ever worked because every module sat at `images/<name>/`; `lib/go/<name>/` is one level deeper and `e2e/` is one shallower.
- **Directories whose name starts with `.` or `_` are pruned.** The go tool ignores them, and a reused runner workspace leaves whole checkouts of other repositories in some of them — `e2e/_storage-e2e` is the one that would otherwise have been linted as if it were ours, from the same dirty workspace that has already produced spurious `dmt` failures.

`scripts/go_linter.sh` is a standalone copy of the template's script that no template consumes; it is updated in step so the two do not drift further apart.

Cherry-picked from `v16.0` (`3eddcdd`).

## Why do we need it, and what problem does it solve?

Findings in `lib/go` and `e2e` never reached anyone. `csi-scsi-generic` carries 13 in `lib/go/common` and 4 in `e2e` that have been sitting on `main` unreported, and were only found by running `golangci-lint` by hand during a review.

Coverage change measured across the storage modules:

| module | modules linted before | after |
|---|---|---|
| csi-scsi-generic | 2 | 4 |
| csi-nfs | 6 | 8 |
| sds-node-configurator | 5 | 7 |
| csi-huawei | 2 | 3 |
| snapshot-controller | 1 | 1 |
| storage-foundation | 5 | 5 |

## Expected result

`go_linter` reports on `lib/go/*` and `e2e` in every repository that has them, and is unchanged everywhere else. `.go_linter` keeps `allow_failure: true`, so newly covered modules report without blocking anyone's pipeline while the backlog is worked off.

## Checklist

- [x] `bash -n` passes on both the script and the script block extracted from the template
- [x] The template still parses as YAML
- [x] Root discovery verified against six storage modules, including two that have no `lib/go` or `e2e`
- [x] Prune verified to skip a planted `e2e/_storage-e2e/go.mod`
